### PR TITLE
Better use Java int than short (same for int and long). 

### DIFF
--- a/3.Wrapping_ThingML_into_Kevoree/3.1_ThingML_Components_3_Kevoree_Deployments/timer.thingml
+++ b/3.Wrapping_ThingML_into_Kevoree/3.1_ThingML_Components_3_Kevoree_Deployments/timer.thingml
@@ -1,14 +1,14 @@
 datatype Integer	
 	@c_type "int"
 	@c_byte_size "2"
-	@java_type "short"
+	@java_type "int"
     @js_type "short"
 	@java_primitive "true";
     
 datatype Long
 	@c_type "int"
 	@c_byte_size "4"
-	@java_type "int"
+	@java_type "long"
     @js_type "int"
 	@java_primitive "true";
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/27122610/why-does-the-java-api-use-int-instead-of-short-or-byte.

short x = 1;
short y = 2;
short z = x + y; // compile error!
short z = (short) (x + y);  // addition is forces auto boxing to int.