### PR TITLE
Better use Java int than short (same for int and long). 

### DIFF
--- a/1.ThingML_Basics/5.Contrib/SAG/Creative.thingml
+++ b/1.ThingML_Basics/5.Contrib/SAG/Creative.thingml
@@ -6,7 +6,7 @@ datatype String
 	@js_type "String";
 
 datatype Integer	
-	@java_type "short"
+	@java_type "int"
 	@js_type "short";
 
 

--- a/1.ThingML_Basics/5.Contrib/SAG/README.md
+++ b/1.ThingML_Basics/5.Contrib/SAG/README.md
@@ -1,0 +1,11 @@
+1. Generate Java code with `HEADS / ThingML --> Plain Java` on file _java/JavaPrint.thingml.
+* Build with `mvn clean package`. 
+* Run example with `mvn exec:java -Dexec.mainClass=com.softwareag.research.heads.Main`.
+You should see 
+```
+Light Actuator Start
+Motion Sensor Start
+Light is ON
+Light is OFF
+``` 
+Stop the app with ctrl-C.

--- a/3.Wrapping_ThingML_into_Kevoree/3.2_Automatically_Wrapping_JS_Code/_javascript/timer.thingml
+++ b/3.Wrapping_ThingML_into_Kevoree/3.2_Automatically_Wrapping_JS_Code/_javascript/timer.thingml
@@ -67,7 +67,7 @@ The ThingML to Kevoree/JS transformation is not implemented yet.
 However it is possible to manually wrap the JS code generated from ThingML
 into Kevoree/JS components.
 
-See 3.2_Manually_Wrapping_JS_Code to see how we did it,
+See 3.2_Automatically_Wrapping_JS_Code to see how we did it,
 and run the different deployments. You should obtain the same results as in Java
 */
 /*configuration TestTimerJS {

--- a/3.Wrapping_ThingML_into_Kevoree/3.2_Automatically_Wrapping_JS_Code/timer.thingml
+++ b/3.Wrapping_ThingML_into_Kevoree/3.2_Automatically_Wrapping_JS_Code/timer.thingml
@@ -1,14 +1,14 @@
 datatype Integer	
 	@c_type "int"
 	@c_byte_size "2"
-	@java_type "short"
+	@java_type "int"
     @js_type "short"
 	@java_primitive "true";
     
 datatype Long
 	@c_type "int"
 	@c_byte_size "4"
-	@java_type "int"
+	@java_type "long"
     @js_type "int"
 	@java_primitive "true";
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/27122610/why-does-the-java-api-use-int-instead-of-short-or-byte.

short x = 1;
short y = 2;
short z = x + y; // compile error!
short z = (short) (x + y);  // addition is forces auto boxing to int.